### PR TITLE
Fix link to Roomba site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Artoo Adaptor For Roomba
 
-This repository contains the Artoo (http://artoo.io/) adaptor for the iRobot Roomba or Create robots (http://www.irobot.com/us/learn/Educators/Create.aspx).
+This repository contains the Artoo (http://artoo.io/) adaptor for the iRobot Roomba or Create robots (http://www.irobot.com/About-iRobot/STEM.aspx).
 
 Artoo is a open source micro-framework for robotics using Ruby.
 


### PR DESCRIPTION
Update URL to point to current location of iRobot Create description

NOTE: Based on a [similar pull request on the main artoo repo](https://github.com/hybridgroup/artoo/pull/146)

This current URL currently redirects to the proposed URL. This proposal updates the URL to avoid the redirect, and keep things consistent with the other artoo documentation.
